### PR TITLE
Improved network testing

### DIFF
--- a/examples/02_TensorRT_GRPC/protos/inference.proto
+++ b/examples/02_TensorRT_GRPC/protos/inference.proto
@@ -40,6 +40,7 @@ message BatchInput {
 
     uint32 int_offset = 4;
     uint64 sysv_offset = 5;
+    bytes data = 6;
 }
 
 message BatchPredictions {

--- a/examples/02_TensorRT_GRPC/src/server.cc
+++ b/examples/02_TensorRT_GRPC/src/server.cc
@@ -175,6 +175,7 @@ class FlowersContext final : public Context<BatchInput, BatchPredictions, Flower
         for (int p = 0; p < N; p++)
         {
             auto element = output.add_elements();
+            /* Customize the post-processing of the output tensor *\
             float max_val = -1.0;
             int max_idx = -1;
             for (int i = 0; i < nClasses; i++)
@@ -189,6 +190,7 @@ class FlowersContext final : public Context<BatchInput, BatchPredictions, Flower
             auto top1 = element->add_predictions();
             top1->set_class_id(max_idx);
             top1->set_score(max_val);
+            \* Customize the post-processing of the output tensor */
         }
         output.set_batch_id(input.batch_id());
     }
@@ -204,6 +206,11 @@ DEFINE_string(engine, "/path/to/tensorrt.engine", "TensorRT serialized engine");
 DEFINE_validator(engine, &ValidateEngine);
 DEFINE_string(dataset, "127.0.0.1:4444", "GRPC Dataset/SharedMemory Service Address");
 DEFINE_int32(contexts, 1, "Number of Execution Contexts");
+DEFINE_int32(buffers,  0, "Number of Input/Output Buffers");
+DEFINE_int32(execution_threads, 1, "Number of RPC execution threads");
+DEFINE_int32(preprocessing_threads, 0, "Number of preprocessing threads");
+DEFINE_int32(kernel_launching_threads, 1, "Number of threads to launch CUDA kernels");
+DEFINE_int32(postprocessing_threads, 2, "Number of postprocessing threads");
 DEFINE_int32(port, 50051, "Port to listen for gRPC requests");
 DEFINE_int32(metrics, 50078, "Port to expose metrics for scraping");
 
@@ -239,14 +246,20 @@ int main(int argc, char *argv[])
     auto rpcCompute = inferenceService->RegisterRPC<FlowersContext>(
         &Inference::AsyncService::RequestCompute);
 
+    // Buffers default to execution contexts + 2
+    // Allows for 1 H2D, N TensorRT Executions, 1 D2H to be inflight
+    auto buffers = FLAGS_buffers;
+    if (buffers == 0)
+        buffers = FLAGS_contexts + 2;
+
     // Initialize Resources
     LOG(INFO) << "Initializing Resources for RPC (flowers::Inference::Compute)";
     auto rpcResources = std::make_shared<FlowersResources>(
-        FLAGS_contexts,                    // number of IExecutionContexts - scratch space for DNN activations
-        FLAGS_contexts + 2,                // number of host/device buffers for input/output tensors
-        1,                             // number of threads used to execute cuda kernel launches
-        2,                             // number of threads used to write and complete responses
-        GetSharedMemory(FLAGS_dataset) // pointer to data in shared memory
+        FLAGS_contexts,                 // number of IExecutionContexts - scratch space for DNN activations
+        buffers,                        // number of host/device buffers for input/output tensors
+        FLAGS_kernel_launching_threads, // number of threads used to execute cuda kernel launches
+        FLAGS_postprocessing_threads,   // number of threads used to write and complete responses
+        GetSharedMemory(FLAGS_dataset)  // pointer to data in shared memory
     );
     rpcResources->RegisterModel("flowers", Runtime::DeserializeEngine(FLAGS_engine));
     rpcResources->AllocateResources();

--- a/examples/97_SingleProcessMultiSteam/launch_service.sh
+++ b/examples/97_SingleProcessMultiSteam/launch_service.sh
@@ -31,9 +31,8 @@ cleanup() {
 }
 trap "cleanup" EXIT SIGINT SIGTERM
 
-NCTX=${1:-1}
-BS=${2:-1}
-ENG=${3:-/work/models/ResNet-50-b1-int8.engine}
+ENG=${1:-/work/models/ResNet-50-b1-fp32.engine}
+NCTX=${2:-1}
 
 if [ ! -e $ENG ]; then
     echo "$ENG not found"

--- a/tests/TestMemory.cc
+++ b/tests/TestMemory.cc
@@ -100,6 +100,8 @@ TEST_F(TestBytesToString, StringToBytes)
     EXPECT_EQ(    8000000, StringToBytes("8.0MB"));
     EXPECT_EQ(    8388608, StringToBytes("8.0MiB"));
     EXPECT_EQ(18253611008, StringToBytes("17GiB"));
+    EXPECT_DEATH(StringToBytes("17G"), "");
+    EXPECT_DEATH(StringToBytes("yais"), "");
 }
 
 } // namespace

--- a/tests/TestMemory.cc
+++ b/tests/TestMemory.cc
@@ -86,4 +86,20 @@ TEST_F(TestBytesToString, BytesToString)
     EXPECT_EQ(  string("1.7 TiB"), BytesToString(1855425871872));
 }
 
+TEST_F(TestBytesToString, StringToBytes)
+{
+    EXPECT_EQ(          0, StringToBytes("0B"));
+    EXPECT_EQ(          0, StringToBytes("0GB"));
+    EXPECT_EQ(       1000, StringToBytes("1000B"));
+    EXPECT_EQ(       1000, StringToBytes("1000b"));
+    EXPECT_EQ(       1000, StringToBytes("1kb"));
+    EXPECT_EQ(       1023, StringToBytes("1023b"));
+//  EXPECT_EQ(       1023, StringToBytes("1.023kb")); // no effort to control rounding - this fails with 1022
+    EXPECT_EQ(       1024, StringToBytes("1kib"));
+    EXPECT_EQ(       1024, StringToBytes("1.0KiB"));
+    EXPECT_EQ(    8000000, StringToBytes("8.0MB"));
+    EXPECT_EQ(    8388608, StringToBytes("8.0MiB"));
+    EXPECT_EQ(18253611008, StringToBytes("17GiB"));
+}
+
 } // namespace

--- a/yais/include/YAIS/Memory.h
+++ b/yais/include/YAIS/Memory.h
@@ -33,6 +33,7 @@ namespace yais
 {
 
 std::string BytesToString(size_t bytes);
+std::uint64_t StringToBytes(const std::string);
 
 /**
  * @brief Abstract base Memory class

--- a/yais/include/YAIS/Server.h
+++ b/yais/include/YAIS/Server.h
@@ -57,6 +57,8 @@ class Server
     void Run();
     void Run(milliseconds timeout, std::function<void()> control_fn);
 
+    ::grpc::ServerBuilder& GetBuilder();
+
   private:
     bool m_Running;
     std::string m_ServerAddress;

--- a/yais/src/Memory.cc
+++ b/yais/src/Memory.cc
@@ -157,7 +157,7 @@ std::uint64_t StringToBytes(const std::string str)
 	LOG(FATAL) << "Unable to convert \"" << str << "\" to bytes. "
                    << "Expected format: 10b, 1024B, 1KiB, 10MB, 2.4gb, etc.";
 
-    std::uint64_t base = m[3] == "" ? 1000 : 1024;
+    const std::uint64_t base = m.empty() || (m.size() > 3 && m[3] == "") ? 1000 : 1024;
     auto exponent = prefix[m[2].str()[0]];
     auto scalar = std::stod(m[1]);
     return (std::uint64_t)(scalar * pow(base, exponent));

--- a/yais/src/Server.cc
+++ b/yais/src/Server.cc
@@ -35,7 +35,15 @@ Server::Server(std::string server_address)
     : m_ServerAddress(server_address), m_Running(false)
 {
     LOG(INFO) << "gRPC listening on: " << m_ServerAddress;
-    m_Builder.AddListeningPort(m_ServerAddress, ::grpc::InsecureServerCredentials());    
+    m_Builder.AddListeningPort(m_ServerAddress, ::grpc::InsecureServerCredentials());
+}
+
+::grpc::ServerBuilder &
+Server::GetBuilder()
+{
+    if (m_Running)
+        LOG(FATAL) << "Unable to access Builder after the Server is running.";
+    return m_Builder;
 }
 
 void 


### PR DESCRIPTION
Exposed access to the `grpc::ServerBuilder` owned by `yais::Server`.  This allows one to configure all aspects of the server.   Using this option, we can now set properties like `MaxReceiveMessageSize` for our gRPC service.

```
    // Modify MaxReceiveMessageSize
    auto bytes = yais::StringToBytes(FLAGS_max_recv_bytes);
    server.GetBuilder().SetMaxReceiveMessageSize(bytes);
    LOG(INFO) << "gRPC MaxReceiveMessageSize = " << yais::BytesToString(bytes);
```

To add network stress, the `siege.x` client can now send an arbitrary number of extra bytes as part of the request payload.  This allows one to increase the size of the message being sent which may help flush out any network bottlenecks.

```
/work/build/examples/02_TensorRT_GRPC/siege.x --rate=2000 --port=50051 --batch_size=1  --max_outstanding=5 --bytes=1MiB
```

Using human friendly strings, e.g. `1MiB`, `2.3kb`, to specify number of bytes for CLI options.