### PR TITLE
Runtime refactor

### DIFF
--- a/examples/00_TensorRT/CMakeLists.txt
+++ b/examples/00_TensorRT/CMakeLists.txt
@@ -27,6 +27,8 @@
 include_directories(${CUDA_INCLUDE_DIRS})
 include_directories(${TensorRT_INCLUDE_DIRS})
 
+
+
 add_executable(inference.x
     inference.cc
     ${PROTO_SRCS}

--- a/examples/00_TensorRT/CMakeLists.txt
+++ b/examples/00_TensorRT/CMakeLists.txt
@@ -38,6 +38,17 @@ target_link_libraries(inference.x
     gflags
 )
 
+add_executable(infer.x
+    infer.cc
+    ${PROTO_SRCS}
+    ${PROTO_GRPC_SRCS})
+
+target_link_libraries(infer.x
+    tensorrt-playground::nvrpc
+    tensorrt-playground::tensorrt
+    gflags
+)
+
 if(YAIS_ENABLE_MPI)
 find_package(MPI)
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})

--- a/examples/00_TensorRT/infer.cc
+++ b/examples/00_TensorRT/infer.cc
@@ -47,9 +47,8 @@ using yais::TensorRT::Bindings;
 using yais::TensorRT::InferenceManager;
 using yais::TensorRT::InferRunner;
 using yais::TensorRT::Runtime;
-using yais::TensorRT::CustomRuntime;
-using yais::TensorRT::StandardAllocator;
-using yais::TensorRT::ManagedAllocator;
+using yais::TensorRT::StandardRuntime;
+using yais::TensorRT::ManagedRuntime;
 
 static std::string ModelName(int model_id)
 {
@@ -179,11 +178,11 @@ int main(int argc, char* argv[])
     std::shared_ptr<Runtime> runtime;
     if(FLAGS_runtime == "default")
     {
-        runtime = std::make_shared<CustomRuntime<StandardAllocator>>();
+        runtime = std::make_shared<StandardRuntime>();
     }
     else if(FLAGS_runtime == "unified")
     {
-        runtime = std::make_shared<CustomRuntime<ManagedAllocator>>();
+        runtime = std::make_shared<ManagedRuntime>();
     }
     else
     {

--- a/examples/00_TensorRT/infer.cc
+++ b/examples/00_TensorRT/infer.cc
@@ -1,0 +1,204 @@
+/* Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "tensorrt/playground/core/thread_pool.h"
+#include "tensorrt/playground/inference_manager.h"
+#include "tensorrt/playground/infer_runner.h"
+#include "tensorrt/playground/runtime.h"
+
+#ifdef YAIS_USE_MPI
+#include "mpi.h"
+#define MPI_CHECK(mpicall) mpicall
+#else
+#define MPI_CHECK(mpicall)
+#endif
+
+using yais::ThreadPool;
+using yais::TensorRT::InferenceManager;
+using yais::TensorRT::ManagedRuntime;
+using yais::TensorRT::Runtime;
+using yais::TensorRT::InferRunner;
+using yais::TensorRT::Bindings;
+
+static int g_Concurrency = 0;
+
+static std::string ModelName(int model_id)
+{
+    std::ostringstream stream;
+    stream << model_id;
+    return stream.str();
+}
+
+class InferenceResources : public InferenceManager
+{
+  public:
+    InferenceResources(int max_executions, int max_buffers)
+        : InferenceManager(max_executions, max_buffers)
+    {
+        RegisterThreadPool("pre", std::make_unique<ThreadPool>(1));
+        RegisterThreadPool("cuda", std::make_unique<ThreadPool>(1));
+        RegisterThreadPool("post", std::make_unique<ThreadPool>(3));
+    }
+
+    ~InferenceResources() override {}
+};
+
+class Inference final
+{
+  public:
+    Inference(std::shared_ptr<InferenceResources> resources) : m_Resources(resources) {}
+
+    void Run(float seconds, bool warmup, int replicas, uint32_t requested_batch_size)
+    {
+        int replica = 0;
+        uint64_t inf_count = 0;
+
+        auto start = std::chrono::steady_clock::now();
+        auto elapsed = [start]() -> float {
+            return std::chrono::duration<float>(std::chrono::steady_clock::now() - start).count();
+        };
+
+        auto model = GetResources()->GetModel(ModelName(replica++));
+        auto batch_size = requested_batch_size ? requested_batch_size : model->GetMaxBatchSize();
+        if(batch_size > model->GetMaxBatchSize())
+        {
+            LOG(FATAL)
+                << "Requested batch_size greater than allowed by the compiled TensorRT Engine";
+        }
+
+        // Inference Loop - Main thread copies, cuda thread launches, response thread completes
+        if(!warmup)
+        {
+            LOG(INFO) << "-- Inference: Running for ~" << (int)seconds
+                      << " seconds with batch_size " << batch_size << " --";
+        }
+
+        std::vector<std::shared_future<bool>> futures;
+
+        while(elapsed() < seconds && ++inf_count)
+        {
+            if(replica >= replicas)
+                replica = 0;
+
+            // This thread only async copies buffers H2D
+            auto model = GetResources()->GetModel(ModelName(replica++));
+            auto buffers = GetResources()->GetBuffers(); // <=== Limited Resource; May Block !!!
+            auto bindings = buffers->CreateBindings(model);
+            bindings->SetBatchSize(batch_size);
+            InferRunner runner(model, GetResources());
+            futures.push_back(runner.Infer(
+                bindings,
+                [](std::shared_ptr<Bindings>& bindings) mutable -> bool {
+                    bindings.reset();
+                    return true;
+                }
+            ));
+        }
+
+        // Join worker threads
+        for (auto& f : futures) {
+            f.wait();
+        }
+
+        // End timing and report
+        auto total_time = std::chrono::duration<float>(elapsed()).count();
+        auto inferences = inf_count * batch_size;
+        if(!warmup)
+            LOG(INFO) << "Inference Results: " << inf_count << "; batches in " << total_time
+                      << " seconds"
+                      << "; sec/batch/stream: " << total_time / (inf_count / g_Concurrency)
+                      << "; batches/sec: " << inf_count / total_time
+                      << "; inf/sec: " << inferences / total_time;
+    }
+
+  protected:
+    inline std::shared_ptr<InferenceResources> GetResources()
+    {
+        return m_Resources;
+    }
+
+  private:
+    std::shared_ptr<InferenceResources> m_Resources;
+};
+
+static bool ValidateEngine(const char* flagname, const std::string& value)
+{
+    struct stat buffer;
+    return (stat(value.c_str(), &buffer) == 0);
+}
+
+DEFINE_string(engine, "/path/to/tensorrt.engine", "TensorRT serialized engine");
+DEFINE_validator(engine, &ValidateEngine);
+DEFINE_int32(seconds, 5, "Approximate number of seconds for the timing loop");
+DEFINE_int32(contexts, 1, "Number of Execution Contexts");
+DEFINE_int32(buffers, 0, "Number of Buffers (default: 2x contexts)");
+DEFINE_int32(cudathreads, 1, "Number Cuda Launcher Threads");
+DEFINE_int32(respthreads, 1, "Number Response Sync Threads");
+DEFINE_int32(replicas, 1, "Number of Replicas of the Model to load");
+DEFINE_int32(batch_size, 0, "Overrides the max batch_size of the provided engine");
+
+int main(int argc, char* argv[])
+{
+    FLAGS_alsologtostderr = 1; // Log to console
+    ::google::InitGoogleLogging("TensorRT Inference");
+    ::google::ParseCommandLineFlags(&argc, &argv, true);
+
+    MPI_CHECK(MPI_Init(&argc, &argv));
+
+    auto contexts = g_Concurrency = FLAGS_contexts;
+    auto buffers = FLAGS_buffers ? FLAGS_buffers : 2 * FLAGS_contexts;
+
+    auto resources = std::make_shared<InferenceResources>(contexts, buffers);
+    
+    //, FLAGS_cudathreads, FLAGS_respthreads);
+
+    resources->RegisterModel("0", ManagedRuntime::DeserializeEngine(FLAGS_engine));
+    resources->AllocateResources();
+
+    for(int i = 1; i < FLAGS_replicas; i++)
+    {
+        resources->RegisterModel(ModelName(i), ManagedRuntime::DeserializeEngine(FLAGS_engine));
+    }
+
+    Inference inference(resources);
+    inference.Run(0.1, true, 1, 0); // warmup
+
+    // if testing mps - sync all processes before executing timed loop
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    inference.Run(FLAGS_seconds, false, FLAGS_replicas, FLAGS_batch_size);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // todo: perform an mpi_allreduce to collect the per process timings
+    //       for a simplified report
+    MPI_CHECK(MPI_Finalize());
+    return 0;
+}

--- a/models/setup.py
+++ b/models/setup.py
@@ -31,26 +31,26 @@ import subprocess
 
 models = [
     ("ResNet-50-deploy.prototxt", "prob"),
-#   ("ResNet-152-deploy.prototxt", "prob"),
+    ("ResNet-152-deploy.prototxt", "prob"),
 ]
 
 precisions = [
     ("fp32", ""),
-#   ("fp16", "--fp16"),
-#   ("int8", "--int8")
+    ("fp16", "--fp16"),
+    ("int8", "--int8")
 ]
 
 def main():
     for model, o in models:
         for name, p in precisions:
-            for b in [1]: #, 2, 4, 8]:
+            for b in [1, 8]: #, 2, 4, 8]:
                 n = "b{}-{}".format(b, name)
                 e = model.replace("prototxt", "engine")
                 e = e.replace("deploy", n)
                 m = os.path.join("/work/models", model)
                 if os.path.isfile(e):
                     continue
-                subprocess.call("giexec --deploy={} --batch={} --output={} {} --engine={}".format(
+                subprocess.call("giexec --deploy={} --batch={} --output={} {} --saveEngine={}".format(
                     m, b, o, p, e
                 ), shell=True)
 

--- a/notebooks/TensorRT Runtime.ipynb
+++ b/notebooks/TensorRT Runtime.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,9 +35,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "&&&& RUNNING TensorRT.trtexec # trtexec --onnx=/work/models/onnx/mnist-v1.3/model.onnx --saveEngine=/work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n",
+      "[I] onnx: /work/models/onnx/mnist-v1.3/model.onnx\n",
+      "[I] saveEngine: /work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n",
+      "----------------------------------------------------------------\n",
+      "Input filename:   /work/models/onnx/mnist-v1.3/model.onnx\n",
+      "ONNX IR version:  0.0.3\n",
+      "Opset version:    8\n",
+      "Producer name:    CNTK\n",
+      "Producer version: 2.5.1\n",
+      "Domain:           ai.cntk\n",
+      "Model version:    1\n",
+      "Doc string:       \n",
+      "----------------------------------------------------------------\n",
+      "[I] [TRT] Detected 1 input and 1 output network tensors.\n",
+      "[I] Engine has been successfully saved to /work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n",
+      "[I] name= Input3, bindingIndex=0, buffers.size()=2\n",
+      "[I] name= Plus214_Output_0, bindingIndex=1, buffers.size()=2\n",
+      "[I] Average over 10 runs is 0.0664576 ms (host walltime is 0.108485 ms, 99% percentile time is 0.093184).\n",
+      "[I] Average over 10 runs is 0.0638976 ms (host walltime is 0.107837 ms, 99% percentile time is 0.069632).\n",
+      "[I] Average over 10 runs is 0.0630784 ms (host walltime is 0.106833 ms, 99% percentile time is 0.06656).\n",
+      "[I] Average over 10 runs is 0.0628736 ms (host walltime is 0.106496 ms, 99% percentile time is 0.064512).\n",
+      "[I] Average over 10 runs is 0.0628736 ms (host walltime is 0.106683 ms, 99% percentile time is 0.064512).\n",
+      "[I] Average over 10 runs is 0.062976 ms (host walltime is 0.107107 ms, 99% percentile time is 0.067584).\n",
+      "[I] Average over 10 runs is 0.0621568 ms (host walltime is 0.105929 ms, 99% percentile time is 0.065536).\n",
+      "[I] Average over 10 runs is 0.062464 ms (host walltime is 0.10624 ms, 99% percentile time is 0.064512).\n",
+      "[I] Average over 10 runs is 0.0630784 ms (host walltime is 0.103808 ms, 99% percentile time is 0.064512).\n",
+      "[I] Average over 10 runs is 0.0637952 ms (host walltime is 0.107783 ms, 99% percentile time is 0.0768).\n",
+      "&&&& PASSED TensorRT.trtexec # trtexec --onnx=/work/models/onnx/mnist-v1.3/model.onnx --saveEngine=/work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n"
+     ]
+    }
+   ],
    "source": [
     "!trtexec --onnx=/work/models/onnx/mnist-v1.3/model.onnx --saveEngine=/work/models/onnx/mnist-v1.3/mnist-v1.3.engine"
    ]
@@ -53,9 +88,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Logging before InitGoogleLogging() is written to STDERR\n",
+      "I0106 09:35:23.188252 16367 inference_manager.cc:62] -- Initialzing TensorRT Resource Manager --\n",
+      "I0106 09:35:23.188268 16367 inference_manager.cc:63] Maximum Execution Concurrency: 2\n",
+      "I0106 09:35:23.188271 16367 inference_manager.cc:64] Maximum Copy Concurrency: 5\n"
+     ]
+    }
+   ],
    "source": [
     "with display_output():\n",
     "    models = infer.InferenceManager(max_executions=2)"
@@ -72,9 +118,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0106 09:35:29.561686 16367 model.cc:87] Binding: Input3; isInput: true; dtype size: 4; bytes per batch item: 3136\n",
+      "I0106 09:35:29.561710 16367 model.cc:87] Binding: Input3; isInput: true; dtype size: 4; bytes per batch item: 3136\n",
+      "I0106 09:35:29.561717 16367 model.cc:87] Binding: Plus214_Output_0; isInput: false; dtype size: 4; bytes per batch item: 40\n",
+      "I0106 09:35:29.561722 16367 model.cc:87] Binding: Plus214_Output_0; isInput: false; dtype size: 4; bytes per batch item: 40\n",
+      "I0106 09:35:29.563902 16367 inference_manager.cc:137] -- Registering Model: mnist --\n",
+      "I0106 09:35:29.563916 16367 inference_manager.cc:138] Input/Output Tensors require 3.1 KiB\n",
+      "I0106 09:35:29.563922 16367 inference_manager.cc:139] Execution Activations require 55.5 KiB\n"
+     ]
+    }
+   ],
    "source": [
     "with display_output():\n",
     "    mnist = models.register_tensorrt_engine(\"mnist\", \"/work/models/onnx/mnist-v1.3/mnist-v1.3.engine\")"
@@ -91,9 +151,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0106 09:35:32.419229 16367 inference_manager.cc:163] -- Allocating TensorRT Resources --\n",
+      "I0106 09:35:32.419239 16367 inference_manager.cc:164] Creating 2 TensorRT execution tokens.\n",
+      "I0106 09:35:32.419242 16367 inference_manager.cc:165] Creating a Pool of 5 Host/Device Memory Stacks\n",
+      "I0106 09:35:32.419248 16367 inference_manager.cc:166] Each Host Stack contains 32.0 KiB\n",
+      "I0106 09:35:32.419252 16367 inference_manager.cc:167] Each Device Stack contains 128.0 KiB\n",
+      "I0106 09:35:32.419256 16367 inference_manager.cc:168] Total GPU Memory: 896.0 KiB\n"
+     ]
+    }
+   ],
    "source": [
     "with display_output():\n",
     "    models.update_resources()"
@@ -110,18 +183,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Input3': {'dtype': dtype('float32'), 'shape': [1, 28, 28]}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mnist.input_bindings()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Plus214_Output_0': {'dtype': dtype('float32'), 'shape': [10]}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mnist.output_bindings()"
    ]
@@ -139,9 +234,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<infer.InferFuture at 0x7f9fb1344110>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result = mnist.infer(Input3=np.random.random_sample([1,28,28]))\n",
     "result # result is a future"
@@ -149,9 +255,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Plus214_Output_0': array([-0.0429085 , -0.30849236, -1.1172674 ,  0.18745418,  0.26956522,\n",
+       "         0.8740529 ,  0.04995521, -1.3036187 ,  1.2071588 ,  0.03463553],\n",
+       "       dtype=float32)}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result = result.get()\n",
     "result # result is the value of the future - dict of np arrays"
@@ -159,15 +278,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Queue Time: 0.00014897999999963218\n",
+      "Compute Time: 0.00037888700000010544\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0106 09:35:36.705937 16428 infer_runner.h:97] Execute Finished\n"
+     ]
+    }
+   ],
    "source": [
-    "start = time.process_time()\n",
-    "result = mnist.infer(**{k: np.random.random_sample(v['shape']) for k,v in mnist.input_bindings().items()})\n",
-    "print(\"Queue Time: {}\".format(time.process_time() - start))\n",
-    "result = result.get()\n",
-    "print(\"Compute Time: {}\".format(time.process_time() - start))"
+    "with display_output():\n",
+    "    start = time.process_time()\n",
+    "    result = mnist.infer(**{k: np.random.random_sample(v['shape']) for k,v in mnist.input_bindings().items()})\n",
+    "    print(\"Queue Time: {}\".format(time.process_time() - start))\n",
+    "    result = result.get()\n",
+    "    print(\"Compute Time: {}\".format(time.process_time() - start))"
    ]
   },
   {
@@ -181,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,9 +327,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAEyVJREFUeJzt3XuMXOV5BvDnnct67fUaX1nWN3yRSXFI48DWJAqqEi6OA6kMVetgNZEdUZw/QGoSWhVRtUWV2iLSgKI2pdrElk1DCW0IxVWdCzipDCggrxHYgA34jl3jxaztXd/WszNv/9hDupg977eeM3POrN/nJ1nenXfPmc+z+3hm5z3f94mqgoj8yWU9ACLKBsNP5BTDT+QUw0/kFMNP5BTDT+QUw0/kFMNP5BTDT+RUIc07a5Ix2oyWNO/y4iCBepKLNCVw8oRXgEo+H3/qcjnZuQvx5wYAHaj+/FIs2uculao+dz2dxSmc0/7QTwyAhOEXkaUAvgsgD+AHqvqA9fXNaMG1ckOSu7w4BQJoBQgAdGCg+rsuNtnnDgW0YtfzEy6JrZWPn7DPHZCfNMWsl9/viS8G/lMrtE036wOH/tesZ+Ul3TTir636Zb+I5AF8D8AXASwEsEJEFlZ7PiJKV5Lf+RcD2KWqe1T1HIAfAVhWm2ERUb0lCf8MAO8M+fxgdNuHiMhqEekSka4S+hPcHRHVUt3f7VfVTlXtUNWOIsbU++6IaISShP8QgFlDPp8Z3UZEo0CS8G8BsEBE5opIE4DbAWyozbCIqN6qbvWp6oCI3A3g5xhs9a1V1ddrNjJH8hMnmvXysWNVnzs3bpxZr5w+bZ8g0IbMT5hg1s12Xs5uYQYFWqBWO08K9o9++Uh3NSMaVRL1+VV1I4CNNRoLEaWIl/cSOcXwEznF8BM5xfATOcXwEznF8BM5lep8fq9CvXY9dy7Z+Vvi10ionDqV7NyBsZd7e6s+d6G9zayHps0Ge/HGNQr59svs+37noH3q0FToUrLvaRr4zE/kFMNP5BTDT+QUw0/kFMNP5BTDT+QUW30pCE6bDQlMq03UzqvnuQOSroCbnxi/MjBgTycOtfJCU5UTf08bAJ/5iZxi+ImcYviJnGL4iZxi+ImcYviJnGL4iZxinz8F+SmTzbq5myyA/NSp9h30G9ugXWrvZKvj7F2Uct32suFHl8wz61O+tj+2VqrYS28XvjXerFfe2G3Wk0gyVXm04DM/kVMMP5FTDD+RUww/kVMMP5FTDD+RUww/kVOJ+vwisg9AH4AygAFV7ajFoC42oT5+yJsPzzTrb31+TWztjNpLSOcC//8frdjHt+Xt6wQsY6Ro1peMX2XW83l77FqKr8kYe9xqXTsBINfaatYrfX1mvRHU4iKfz6vq0Rqch4hSxJf9RE4lDb8C+IWIbBWR1bUYEBGlI+nL/utU9ZCIXArgGRHZqaqbh35B9J/CagBohr31ExGlJ9Ezv6oeiv7uBvAUgMXDfE2nqnaoakcR1b85RES1VXX4RaRFRFo/+BjAEgCv1WpgRFRfSV72twF4SgaXfi4A+DdV/VlNRkVEdVd1+FV1D4BP1nAsF63QNtfHl/22Wf/KJ54z63mJfwG3v6Tmsa05u48/u2DPqS9rxaz360Bs7VjFXvv+k//4qn3uiv3ju+0vfye2NuanW8xjCzOmm/Wkew40Arb6iJxi+ImcYviJnGL4iZxi+ImcYviJnBJVuxVUSxNksl4rN6R2f6PFip1222jVhG6zvrt0MrY2v2i36k5Uzpj1POwtvENTgiuIbwWOzzWbx4bsNf7dAPDquctia/9053Lz2Pz/vGzXJ00y6+Vj9pLn9fKSbkKv9tjftAif+YmcYviJnGL4iZxi+ImcYviJnGL4iZxi+ImcGl1bdIvRvjSmtQ6W7danVhJc7xCY1orAtRRr7rvNrE9/cK1ZXzIuvpcfmnLbVymb9esf+zOzPv9xu59daY5fnvvAUnv56y2rHzLrcwPXMEzMxV8f8ae32KtKfWzXDLM+cPCQWR8N+MxP5BTDT+QUw0/kFMNP5BTDT+QUw0/kFMNP5FT68/lzN1Z/ghTHWktJ536fWfaRjZA+pOfK+Ms1Bsaah0IL9mM674lAH3/bTvsOErhqq/3c9M1pm836zMCy45YvTF9k1jmfn4hGLYafyCmGn8gphp/IKYafyCmGn8gphp/IqeB8fhFZC+BLALpV9arotskAngAwB8A+AMtVdWSNTWvefWhefJYSrCWQtOc79r+2mvWZG/OxNS3ZW3DnJ15i1svHT5j10PbjqMR/Tytnz5qHvvCwfX3DN//O7vMnIcUms55VH7+WRvLMvw7A0vNuuxfAJlVdAGBT9DkRjSLB8KvqZgA95928DMD66OP1AG6t8biIqM6q/Z2/TVUPRx+/C6CtRuMhopQkfsNPBycHxF4gLiKrRaRLRLpK6E96d0RUI9WG/4iItANA9HfsSomq2qmqHaraUYS9aCIRpafa8G8AsDL6eCWAp2szHCJKSzD8IvI4gF8D+JiIHBSROwA8AOAmEXkbwI3R50Q0igT7/Kq6IqZ0Q1X3GFgnvmpWHx5IvK5/6HiLBv7N+alTzHr56PuJzm8eW052bUXlbOB9nARjm7TtuFlPMl+/pPa4cmOb7RME6uXe3gsdUup4hR+RUww/kVMMP5FTDD+RUww/kVMMP5FT3KI7Etyiu2JPjTXvu2A/zOUeu6UVkp8y2Ti53dIKTdkNCrTycs3xLTEZa68r/s4S4981Atb25CcrgRblmMDVqAMDVYyosfCZn8gphp/IKYafyCmGn8gphp/IKYafyCmGn8ipxurzh6blWgLLfutAdtt7a6DXnlT5/fPXV/1/EuhXW314AJBm+/jQdQLW8tyFwLLh839vt1k/Wj5l1qfmW2JrfaFl4gPXL3hZupuILkIMP5FTDD+RUww/kVMMP5FTDD+RUww/kVPp9vnFntsenlNf3365KRe/Dbbk42sjUc9ttEufvco89ugn7D5+4Yz9PZm2/mWzbhpnz+fvnPeYWU+y6PgPj19j1q1rJwAg19pq1it9fRc8prTxmZ/IKYafyCmGn8gphp/IKYafyCmGn8gphp/IqWCfX0TWAvgSgG5VvSq67X4AdwJ4L/qy+1R1Y/juxF5fX0vhU1QrsFZALrCGvLTEzw2XpqJ57IEVc8y6Br4Lc5buNesTi/GP6b0zvmcee2XRHnsl0E2/82v2Tu0VjR/bVy79qXnsWbWvMWjL29cofLtnfmzthS/MNY/NjbO32B4NffyQkTzzrwOwdJjbH1bVRdGfEQSfiBpJMPyquhmAfbkTEY06SX7nv1tEtonIWhGZVLMREVEqqg3/IwDmA1gE4DCA78R9oYisFpEuEekqafx6bkSUrqrCr6pHVLWsqhUA3wew2PjaTlXtUNWOotiLRRJReqoKv4i0D/n0NgCv1WY4RJSWkbT6HgfwOQBTReQggL8G8DkRWQRAAewD8PU6jpGI6iAYflVdMczNa6q6N1Vz7roUm+zDA/PeLfmFV5j1fb8/xaz/1k1vx9Y65/6Heay1fjwA7C2dNOtzi+PN+sGB+ONnFuxjQ/aWzpj1f5n1rFkfl4v/nr5Vstfdn51w7NMK8b34N79l9/kX/M3F/2KWV/gROcXwEznF8BM5xfATOcXwEznF8BM5lf4W3cYS2ElaeSFv3mFPP9h9+z+b9a398WMLtfJCWnP2dONNZ+ylwbefjV+ee9l4u2U1LW//CITajCHHyqdja1cU7cetpPZS7afV/nlZNaE7tnb9l79tHrv846vM+uQ/sh+30bCFN5/5iZxi+ImcYviJnGL4iZxi+ImcYviJnGL4iZxKv89vbLOdZCvq0JbJO79sL2EN2L30a8bET0198azdj37qhL0d9LOPfMasT+38tVkv3Rh//rf+/jLz2Lum/cqsf9yeZY2fnbaXz55ViJ8SfPXP/9g8dux++84/c8s2s75m9vOxtbNqX1vx4qIfm/WlT95i1nE9+/xE1KAYfiKnGH4ipxh+IqcYfiKnGH4ipxh+IqdEA9sg19IluSn66eabY+uVs/Z2XoXLZ8XWBg4cNI9dt/85sx7aHHxGflxsLW9tOw5gzQm7176o+YBZf7c8wazv6W+Lrd3W+rp57GRjaW3AXnobAHaci5+vDwCr/uqe2NrER+3rF0IKM2eYdflh/Pbi6+bbffz3yvZ1AC25wNbls68z6/Xykm5Cr/bYg4/wmZ/IKYafyCmGn8gphp/IKYafyCmGn8gphp/IqWCfX0RmAXgUQBsABdCpqt8VkckAngAwB8A+AMtV1ZzEPEEm67VyQw2GPcw4A9t7H/nxPLP+wjWPmnWr333Y2CIbANoDW02HtuieWRhr1vs1/iqF8blm89i7D11r1n/5n/ZaBJe+Yl8hMea/t8TWCu329Q8DR94z67mmolm3rhspLekwj/3luh+Y9Stf+KpZn/2H2816vdS6zz8A4B5VXQjg0wDuEpGFAO4FsElVFwDYFH1ORKNEMPyqelhVX44+7gOwA8AMAMsArI++bD2AW+s1SCKqvQv6nV9E5gD4FICXALSp6uGo9C4Gfy0golFixOEXkfEAngTwDVXtHVrTwTcOhn3zQERWi0iXiHSV0J9osERUOyMKv4gUMRj8x1T1J9HNR0SkPaq3Axh2V0RV7VTVDlXtKMJe7JGI0hMMv4gIgDUAdqjqQ0NKGwCsjD5eCeDp2g+PiOplJK2+6wA8B2A7gA/mMd6Hwd/7/x3AbAD7Mdjq67HOFWr1FeZebo5lYO9+s27JNdstL1wxxyx3/238FM6rLz1kHrurd6pZb22yfx3af8zeXrztwfg2pLxob9GdH29vk63nkm2bHpqmbZEx9itF7Q/8GilGxyvwc5+fOsWsl3uO2/dtLFFfTxfS6guu26+qzwOIO1l9mvZEVHe8wo/IKYafyCmGn8gphp/IKYafyCmGn8ipVLfolnwO+fHxy1CH+vhW77V89H37vsfa02LL23aa9Wl/EN9zPhDoNzeJvbx1f6DnPL3Z7ilbvfTcuPglxwGg3Ntr1pPKtcRfR1A5dco+NtDnLwced2mKv/4hdI1A6OcpP8FeTr3ej2st8JmfyCmGn8gphp/IKYafyCmGn8gphp/IKYafyKlU+/xarpj9z+AcaqP3Glq6u3zMXFU8KD+jPbY2sGeffXCgj59rbTXrlb4++/yWfL76YwHkJ15i1svHT5j1ymn7Ggfz3KFeec7+twXn+1unzvj6iDTwmZ/IKYafyCmGn8gphp/IKYafyCmGn8gphp/IqVT7/CGhOdQWLSVbXz4k2MtPIFEfv87nDvXxgwLXOCRSx7Xxk1yfMFrwmZ/IKYafyCmGn8gphp/IKYafyCmGn8gphp/IqWD4RWSWiPxKRN4QkddF5E+i2+8XkUMi8kr05+b6D5eIamUkF/kMALhHVV8WkVYAW0Xkmaj2sKr+Q/2GR0T1Egy/qh4GcDj6uE9EdgCYUe+BEVF9XdDv/CIyB8CnALwU3XS3iGwTkbUiMinmmNUi0iUiXSVUv6wSEdXWiMMvIuMBPAngG6raC+ARAPMBLMLgK4PvDHecqnaqaoeqdhRh771GROkZUfhFpIjB4D+mqj8BAFU9oqplVa0A+D6AxfUbJhHV2kje7RcAawDsUNWHhtw+dDnb2wC8VvvhEVG9jOTd/s8C+CqA7SLySnTbfQBWiMgiAApgH4Cv12WERFQXI3m3/3kAMkxpY+2HQ0Rp4RV+RE4x/EROMfxETjH8RE4x/EROMfxETjH8RE4x/EROMfxETjH8RE4x/EROMfxETjH8RE4x/EROidZzC+Xz70zkPQD7h9w0FcDR1AZwYRp1bI06LoBjq1Ytx3a5qk4byRemGv6P3LlIl6p2ZDYAQ6OOrVHHBXBs1cpqbHzZT+QUw0/kVNbh78z4/i2NOrZGHRfAsVUrk7Fl+js/EWUn62d+IspIJuEXkaUi8qaI7BKRe7MYQxwR2Sci26Odh7syHstaEekWkdeG3DZZRJ4Rkbejv4fdJi2jsTXEzs3GztKZPnaNtuN16i/7RSQP4C0ANwE4CGALgBWq+kaqA4khIvsAdKhq5j1hEfldACcBPKqqV0W3PQigR1UfiP7jnKSqf94gY7sfwMmsd26ONpRpH7qzNIBbAaxCho+dMa7lyOBxy+KZfzGAXaq6R1XPAfgRgGUZjKPhqepmAD3n3bwMwPro4/UY/OFJXczYGoKqHlbVl6OP+wB8sLN0po+dMa5MZBH+GQDeGfL5QTTWlt8K4BcislVEVmc9mGG0RdumA8C7ANqyHMwwgjs3p+m8naUb5rGrZsfrWuMbfh91napeDeCLAO6KXt42JB38na2R2jUj2rk5LcPsLP0bWT521e54XWtZhP8QgFlDPp8Z3dYQVPVQ9Hc3gKfQeLsPH/lgk9To7+6Mx/MbjbRz83A7S6MBHrtG2vE6i/BvAbBAROaKSBOA2wFsyGAcHyEiLdEbMRCRFgBL0Hi7D28AsDL6eCWApzMcy4c0ys7NcTtLI+PHruF2vFbV1P8AuBmD7/jvBvAXWYwhZlzzALwa/Xk967EBeByDLwNLGHxv5A4AUwBsAvA2gGcBTG6gsf0rgO0AtmEwaO0Zje06DL6k3wbglejPzVk/dsa4MnnceIUfkVN8w4/IKYafyCmGn8gphp/IKYafyCmGn8gphp/IKYafyKn/Aww8KmPl7DwXAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[  975.6701  ,  -618.72394 ,  6574.5684  ,   668.02893 ,\n",
+       "         -917.27094 , -1671.6359  , -1952.7599  ,   -61.549873,\n",
+       "         -777.17664 , -1439.5316  ]], dtype=float32)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "utils.mnist_image(inputs[0]).show()\n",
     "expected[0]"
@@ -209,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,9 +388,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output Binding Name: Plus214_Output_0; shape: (10,)\n",
+      "Result: 2\n"
+     ]
+    }
+   ],
    "source": [
     "for r, e in zip(results, expected):\n",
     "    for key, val in r.items():\n",

--- a/notebooks/TensorRT Runtime.ipynb
+++ b/notebooks/TensorRT Runtime.ipynb
@@ -59,16 +59,16 @@
       "[I] Engine has been successfully saved to /work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n",
       "[I] name= Input3, bindingIndex=0, buffers.size()=2\n",
       "[I] name= Plus214_Output_0, bindingIndex=1, buffers.size()=2\n",
-      "[I] Average over 10 runs is 0.0664576 ms (host walltime is 0.108485 ms, 99% percentile time is 0.093184).\n",
-      "[I] Average over 10 runs is 0.0638976 ms (host walltime is 0.107837 ms, 99% percentile time is 0.069632).\n",
-      "[I] Average over 10 runs is 0.0630784 ms (host walltime is 0.106833 ms, 99% percentile time is 0.06656).\n",
-      "[I] Average over 10 runs is 0.0628736 ms (host walltime is 0.106496 ms, 99% percentile time is 0.064512).\n",
-      "[I] Average over 10 runs is 0.0628736 ms (host walltime is 0.106683 ms, 99% percentile time is 0.064512).\n",
-      "[I] Average over 10 runs is 0.062976 ms (host walltime is 0.107107 ms, 99% percentile time is 0.067584).\n",
-      "[I] Average over 10 runs is 0.0621568 ms (host walltime is 0.105929 ms, 99% percentile time is 0.065536).\n",
-      "[I] Average over 10 runs is 0.062464 ms (host walltime is 0.10624 ms, 99% percentile time is 0.064512).\n",
-      "[I] Average over 10 runs is 0.0630784 ms (host walltime is 0.103808 ms, 99% percentile time is 0.064512).\n",
-      "[I] Average over 10 runs is 0.0637952 ms (host walltime is 0.107783 ms, 99% percentile time is 0.0768).\n",
+      "[I] Average over 10 runs is 0.0651264 ms (host walltime is 0.107141 ms, 99% percentile time is 0.091136).\n",
+      "[I] Average over 10 runs is 0.0608256 ms (host walltime is 0.103748 ms, 99% percentile time is 0.064512).\n",
+      "[I] Average over 10 runs is 0.0610304 ms (host walltime is 0.103952 ms, 99% percentile time is 0.062464).\n",
+      "[I] Average over 10 runs is 0.0606208 ms (host walltime is 0.103556 ms, 99% percentile time is 0.063488).\n",
+      "[I] Average over 10 runs is 0.0608256 ms (host walltime is 0.101731 ms, 99% percentile time is 0.063488).\n",
+      "[I] Average over 10 runs is 0.0605184 ms (host walltime is 0.10369 ms, 99% percentile time is 0.063488).\n",
+      "[I] Average over 10 runs is 0.0607232 ms (host walltime is 0.103788 ms, 99% percentile time is 0.06144).\n",
+      "[I] Average over 10 runs is 0.0611328 ms (host walltime is 0.101827 ms, 99% percentile time is 0.063488).\n",
+      "[I] Average over 10 runs is 0.0607232 ms (host walltime is 0.103715 ms, 99% percentile time is 0.062464).\n",
+      "[I] Average over 10 runs is 0.0606208 ms (host walltime is 0.105943 ms, 99% percentile time is 0.062464).\n",
       "&&&& PASSED TensorRT.trtexec # trtexec --onnx=/work/models/onnx/mnist-v1.3/model.onnx --saveEngine=/work/models/onnx/mnist-v1.3/mnist-v1.3.engine\n"
      ]
     }
@@ -96,9 +96,9 @@
      "output_type": "stream",
      "text": [
       "WARNING: Logging before InitGoogleLogging() is written to STDERR\n",
-      "I0106 09:35:23.188252 16367 inference_manager.cc:62] -- Initialzing TensorRT Resource Manager --\n",
-      "I0106 09:35:23.188268 16367 inference_manager.cc:63] Maximum Execution Concurrency: 2\n",
-      "I0106 09:35:23.188271 16367 inference_manager.cc:64] Maximum Copy Concurrency: 5\n"
+      "I0108 18:03:07.392199  2869 inference_manager.cc:64] -- Initialzing TensorRT Resource Manager --\n",
+      "I0108 18:03:07.392215  2869 inference_manager.cc:65] Maximum Execution Concurrency: 2\n",
+      "I0108 18:03:07.392217  2869 inference_manager.cc:66] Maximum Copy Concurrency: 5\n"
      ]
     }
    ],
@@ -118,23 +118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "I0106 09:35:29.561686 16367 model.cc:87] Binding: Input3; isInput: true; dtype size: 4; bytes per batch item: 3136\n",
-      "I0106 09:35:29.561710 16367 model.cc:87] Binding: Input3; isInput: true; dtype size: 4; bytes per batch item: 3136\n",
-      "I0106 09:35:29.561717 16367 model.cc:87] Binding: Plus214_Output_0; isInput: false; dtype size: 4; bytes per batch item: 40\n",
-      "I0106 09:35:29.561722 16367 model.cc:87] Binding: Plus214_Output_0; isInput: false; dtype size: 4; bytes per batch item: 40\n",
-      "I0106 09:35:29.563902 16367 inference_manager.cc:137] -- Registering Model: mnist --\n",
-      "I0106 09:35:29.563916 16367 inference_manager.cc:138] Input/Output Tensors require 3.1 KiB\n",
-      "I0106 09:35:29.563922 16367 inference_manager.cc:139] Execution Activations require 55.5 KiB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with display_output():\n",
     "    mnist = models.register_tensorrt_engine(\"mnist\", \"/work/models/onnx/mnist-v1.3/mnist-v1.3.engine\")"
@@ -151,19 +137,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "I0106 09:35:32.419229 16367 inference_manager.cc:163] -- Allocating TensorRT Resources --\n",
-      "I0106 09:35:32.419239 16367 inference_manager.cc:164] Creating 2 TensorRT execution tokens.\n",
-      "I0106 09:35:32.419242 16367 inference_manager.cc:165] Creating a Pool of 5 Host/Device Memory Stacks\n",
-      "I0106 09:35:32.419248 16367 inference_manager.cc:166] Each Host Stack contains 32.0 KiB\n",
-      "I0106 09:35:32.419252 16367 inference_manager.cc:167] Each Device Stack contains 128.0 KiB\n",
-      "I0106 09:35:32.419256 16367 inference_manager.cc:168] Total GPU Memory: 896.0 KiB\n"
+     "ename": "NameError",
+     "evalue": "name 'display_output' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-bd465fa5fbd4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mwith\u001b[0m \u001b[0mdisplay_output\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m     \u001b[0mmodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate_resources\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'display_output' is not defined"
      ]
     }
    ],

--- a/tensorrt-playground/core/benchmarks/bench_memory_stack.cc
+++ b/tensorrt-playground/core/benchmarks/bench_memory_stack.cc
@@ -53,7 +53,7 @@ struct StackWithInternalDescriptor
     void Reset() { m_Stack.Reset(); }
 
   private:
-    MemoryStack<Malloc> m_Stack;
+    MemoryStack<MemoryType> m_Stack;
 };
 
 static void BM_MemoryStack_Allocate(benchmark::State &state)

--- a/tensorrt-playground/nvrpc/include/nvrpc/client/client.h
+++ b/tensorrt-playground/nvrpc/include/nvrpc/client/client.h
@@ -39,7 +39,7 @@ namespace nvrpc {
 namespace client {
 
 template<typename Request, typename Response>
-struct ClientUnary : public ::yais::AsyncCompute<void(Request&, Response&, ::grpc::Status&)>
+struct ClientUnary : public ::yais::AsyncComputeWrapper<void(Request&, Response&, ::grpc::Status&)>
 {
   public:
     using PrepareFn = std::function<std::unique_ptr<::grpc::ClientAsyncResponseReader<Response>>(

--- a/tensorrt-playground/python/tensorrt/src/infer.cc
+++ b/tensorrt-playground/python/tensorrt/src/infer.cc
@@ -121,7 +121,7 @@ class PyInferenceManager final : public InferenceManager
     std::shared_ptr<PyInferRunner> RegisterModelByPath(const std::string& name,
                                                        const std::string& path)
     {
-        auto model = Runtime::DeserializeEngine(path);
+        auto model = ActiveRuntime().DeserializeEngine(path);
         RegisterModel(name, model);
         return this->InferRunner(name);
     }

--- a/tensorrt-playground/python/tensorrt/src/infer.cc
+++ b/tensorrt-playground/python/tensorrt/src/infer.cc
@@ -113,6 +113,9 @@ class PyInferenceManager final : public InferenceManager
         manager->RegisterThreadPool("pre", std::make_unique<ThreadPool>(pre_thread_count));
         manager->RegisterThreadPool("cuda", std::make_unique<ThreadPool>(cuda_thread_count));
         manager->RegisterThreadPool("post", std::make_unique<ThreadPool>(post_thread_count));
+        manager->RegisterRuntime("default", std::make_shared<StandardRuntime>());
+        manager->RegisterRuntime("unified", std::make_shared<ManagedRuntime>());
+        manager->SetActiveRuntime("default");
         return manager;
     }
 

--- a/tensorrt-playground/python/tensorrt/src/infer.cc
+++ b/tensorrt-playground/python/tensorrt/src/infer.cc
@@ -186,7 +186,8 @@ struct PyInferRunner : public InferRunner
                     DLOG(INFO) << "Processing binding: " << binding.name << "with index " << id;
                     auto value = py::array(DataTypeToNumpy(binding.dtype), binding.dims);
                     // auto value = py::array_t<float>(binding.dims);
-                    // auto value = py::array_t<float>(binding.elementsPerBatchItem * bindings->BatchSize());
+                    // auto value = py::array_t<float>(binding.elementsPerBatchItem *
+                    // bindings->BatchSize());
                     py::buffer_info buffer = value.request();
                     CHECK_EQ(value.nbytes(), bindings->BindingSize(id));
                     std::memcpy(buffer.ptr, bindings->HostAddress(id), value.nbytes());
@@ -201,7 +202,7 @@ struct PyInferRunner : public InferRunner
     py::dict InputBindings() const
     {
         auto dict = py::dict();
-        for (const auto& id : GetModel().GetInputBindingIds())
+        for(const auto& id : GetModel().GetInputBindingIds())
         {
             AddBindingInfo(dict, id);
         }
@@ -211,7 +212,7 @@ struct PyInferRunner : public InferRunner
     py::dict OutputBindings() const
     {
         auto dict = py::dict();
-        for (const auto& id : GetModel().GetOutputBindingIds())
+        for(const auto& id : GetModel().GetOutputBindingIds())
         {
             AddBindingInfo(dict, id);
         }
@@ -242,8 +243,11 @@ PYBIND11_MODULE(infer, m)
         .def("infer", &PyInferRunner::Infer)
         .def("input_bindings", &PyInferRunner::InputBindings)
         .def("output_bindings", &PyInferRunner::OutputBindings);
+//      .def("__repr__", [](const PyInferRunner& obj) { 
+//          return obj.Description();
+//      });
 
-    py::class_<std::shared_future<typename PyInferRunner::InferResults>>(m, "InferenceFutureResult")
+    py::class_<std::shared_future<typename PyInferRunner::InferResults>>(m, "InferFuture")
         .def("wait", &std::shared_future<typename PyInferRunner::InferResults>::wait) // py::call_guard<py::gil_scoped_release>())
         .def("get", &std::shared_future<typename PyInferRunner::InferResults>::get); // py::call_guard<py::gil_scoped_release>());
 }

--- a/tensorrt-playground/tensorrt/CMakeLists.txt
+++ b/tensorrt-playground/tensorrt/CMakeLists.txt
@@ -4,6 +4,7 @@ message(STATUS "TensorRT IncludeDir ${TensorRT_INCLUDE_DIRS}")
 message(STATUS "TensorRT Version ${TensorRT_VERSION_STRING}")
 
 add_library(tensorrt
+  src/allocator.cc
   src/bindings.cc
   src/buffers.cc
   src/execution_context.cc

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/infer_runner.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/infer_runner.h
@@ -34,7 +34,7 @@
 namespace yais {
 namespace TensorRT {
 
-struct InferRunner : public AsyncCompute<void(std::shared_ptr<Bindings>&)>
+struct InferRunner : public AsyncComputeWrapper<void(std::shared_ptr<Bindings>&)>
 {
     InferRunner(std::shared_ptr<Model> model, std::shared_ptr<InferenceManager> resources)
         : m_Model{model}, m_Resources{resources}

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
@@ -37,6 +37,7 @@
 #include "tensorrt/playground/core/thread_pool.h"
 #include "tensorrt/playground/core/resources.h"
 #include "tensorrt/playground/common.h"
+#include "tensorrt/playground/runtime.h"
 #include "tensorrt/playground/model.h"
 #include "tensorrt/playground/buffers.h"
 #include "tensorrt/playground/execution_context.h"
@@ -70,18 +71,29 @@ class InferenceManager : public ::yais::Resources
     bool HasThreadPool(const std::string&) const;
     void JoinAllThreads();
 
+    Runtime& ActiveRuntime();
+    void RegisterRuntime(const std::string&, std::unique_ptr<Runtime>);
+    void SetActiveRuntime(const std::string&);
+    void SetActiveRuntimeToDefault();
+
+    int MaxExecConcurrency() const;
+    int MaxCopyConcurrency() const;
+
   private:
     int m_MaxExecutions;
     int m_MaxBuffers;
     size_t m_HostStackSize;
     size_t m_DeviceStackSize;
     size_t m_ActivationsSize;
+    Runtime *m_ActiveRuntime;
+
+    std::map<std::string, std::unique_ptr<ThreadPool>> m_ThreadPools;
+    std::map<std::string, std::unique_ptr<Runtime>> m_Runtimes;
+    std::map<std::string, std::shared_ptr<Model>> m_Models;
+    std::map<const Model *, std::shared_ptr<Pool<::nvinfer1::IExecutionContext>>> m_ModelExecutionContexts;
+
     std::shared_ptr<Pool<Buffers>> m_Buffers;
     std::shared_ptr<Pool<ExecutionContext>> m_ExecutionContexts;
-    std::map<std::string, std::shared_ptr<Model>> m_Models;
-    std::map<std::string, std::unique_ptr<ThreadPool>> m_ThreadPools;
-    std::map<const Model *, std::shared_ptr<Pool<::nvinfer1::IExecutionContext>>> m_ModelExecutionContexts;
-    // mutable std::shared_mutex m_ThreadPoolMutex;
 
     std::size_t Align(std::size_t size, std::size_t alignment)
     {

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
@@ -72,7 +72,7 @@ class InferenceManager : public ::yais::Resources
     void JoinAllThreads();
 
     Runtime& ActiveRuntime();
-    void RegisterRuntime(const std::string&, std::unique_ptr<Runtime>);
+    void RegisterRuntime(const std::string&, std::shared_ptr<Runtime>);
     void SetActiveRuntime(const std::string&);
     void SetActiveRuntimeToDefault();
 
@@ -88,7 +88,7 @@ class InferenceManager : public ::yais::Resources
     Runtime *m_ActiveRuntime;
 
     std::map<std::string, std::unique_ptr<ThreadPool>> m_ThreadPools;
-    std::map<std::string, std::unique_ptr<Runtime>> m_Runtimes;
+    std::map<std::string, std::shared_ptr<Runtime>> m_Runtimes;
     std::map<std::string, std::shared_ptr<Model>> m_Models;
     std::map<const Model *, std::shared_ptr<Pool<::nvinfer1::IExecutionContext>>> m_ModelExecutionContexts;
 

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/inference_manager.h
@@ -46,54 +46,6 @@ namespace yais
 namespace TensorRT
 {
 
-template<typename HostMemoryType, typename DeviceMemoryType>
-class CyclicBuffers : public Buffers
-{
-  public:
-    using HostAllocatorType = std::unique_ptr<Memory::CyclicAllocator<HostMemoryType>>;
-    using DeviceAllocatorType = std::unique_ptr<Memory::CyclicAllocator<DeviceMemoryType>>;
-
-    using HostDescriptor = typename Memory::CyclicAllocator<HostMemoryType>::Descriptor;
-    using DeviceDescriptor = typename Memory::CyclicAllocator<DeviceMemoryType>::Descriptor;
-
-    CyclicBuffers(HostAllocatorType host, DeviceAllocatorType device)
-        : m_HostAllocator{std::move(host)}, m_DeviceAllocator{std::move(device)}
-    {
-    }
-    ~CyclicBuffers() override {}
-
-    HostDescriptor AllocateHost(size_t size)
-    {
-        return m_HostAllocator->Allocate(size);
-    }
-
-    DeviceDescriptor AllocateDevice(size_t size)
-    {
-        return m_DeviceAllocator->Allocate(size);
-    }
-
-    void Reset(bool writeZeros = false) final override {}
-    void ConfigureBindings(const std::shared_ptr<Model>& model, std::shared_ptr<Bindings> bindings) override
-    {
-        for(uint32_t i = 0; i < model->GetBindingsCount(); i++)
-        {
-            auto binding_size = model->GetBinding(i).bytesPerBatchItem * model->GetMaxBatchSize();
-            DLOG(INFO) << "Configuring Binding " << i << ": pushing " << binding_size
-                       << " to host/device stacks";
-            bindings->SetHostAddress(i, m_HostAllocator->Allocate(binding_size));
-            bindings->SetDeviceAddress(i, m_DeviceAllocator->Allocate(binding_size));
-        }
-    }
-
-  private:
-    HostAllocatorType m_HostAllocator;
-    DeviceAllocatorType m_DeviceAllocator;
-};
-
-
-/**
- * @brief TensorRT Resource Manager
- */
 class InferenceManager : public ::yais::Resources
 {
   public:

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
@@ -160,9 +160,6 @@ class Model // TODO: inherit from IModel so we can have non-TensorRT models that
     std::vector<uint32_t> m_OutputBindings;
     std::vector<Weights> m_Weights;
     std::string m_Name;
-
-    friend class Runtime;
-    friend class ManagedRuntime;
 };
 
 

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
@@ -162,5 +162,7 @@ class Model // TODO: inherit from IModel so we can have non-TensorRT models that
     friend class ManagedRuntime;
 };
 
+
+
 } // namespace TensorRT
 } // namespace yais

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/model.h
@@ -32,6 +32,8 @@
 
 #include <NvInfer.h>
 
+#include "tensorrt/playground/runtime.h"
+
 namespace yais {
 namespace TensorRT {
 
@@ -58,7 +60,7 @@ class Model // TODO: inherit from IModel so we can have non-TensorRT models that
      * @param engine
      */
     Model(std::shared_ptr<::nvinfer1::ICudaEngine> engine); // TODO: Move to protected/private
-    virtual ~Model() {}
+    virtual ~Model();
 
     auto Name() const -> const std::string
     {
@@ -150,6 +152,7 @@ class Model // TODO: inherit from IModel so we can have non-TensorRT models that
     };
 
     std::shared_ptr<::nvinfer1::ICudaEngine> m_Engine;
+    std::shared_ptr<const Runtime> m_Runtime;
     std::vector<TensorBindingInfo> m_Bindings;
     std::map<std::string, TensorBindingInfo> m_BindingsByName;
     std::map<std::string, uint32_t> m_BindingIdByName;

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/runtime.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/runtime.h
@@ -33,119 +33,79 @@
 #include <vector>
 
 #include "tensorrt/playground/common.h"
+#include "tensorrt/playground/allocator.h"
 #include "tensorrt/playground/model.h"
 
-namespace yais
+namespace yais {
+namespace TensorRT {
+/**
+ * @brief Convenience class wrapping nvinfer1::IRuntime.
+ *
+ * Provide static method for deserializing a saved TensorRT engine/plan
+ * and implements a Logger that conforms to YAIS logging.
+ */
+class Runtime : public std::enable_shared_from_this<Runtime>
 {
-namespace TensorRT
-{
-    /**
-     * @brief Convenience class wrapping nvinfer1::IRuntime.
-     *
-     * Provide static method for deserializing a saved TensorRT engine/plan
-     * and implements a Logger that conforms to YAIS logging.
-     */
-    class Runtime
+    Runtime(const Runtime&) = delete;
+    Runtime& operator=(const Runtime&) = delete;
+
+    Runtime(Runtime&&) noexcept = delete;
+    Runtime& operator=(Runtime&&) = delete;
+
+  public:
+    virtual ~Runtime();
+
+    std::shared_ptr<Model> DeserializeEngine(const std::string&);
+    std::shared_ptr<Model> DeserializeEngine(const std::string&, ::nvinfer1::IPluginFactory*);
+    std::shared_ptr<Model> DeserializeEngine(const void*, size_t);
+    virtual std::shared_ptr<Model> DeserializeEngine(const void*, size_t, ::nvinfer1::IPluginFactory*) = 0;
+
+  protected:
+    Runtime();
+
+    ::nvinfer1::IRuntime& NvRuntime() const;
+    std::vector<char> ReadEngineFile(const std::string&) const;
+
+  private:
+    class Logger : public ::nvinfer1::ILogger
     {
       public:
-        static std::shared_ptr<Model> DeserializeEngine(std::string plan_file);
-        virtual ~Runtime() {}
-
-      protected:
-        Runtime();
-        // TODO: Runtime(std::unique_ptr<::nvinfer1::ILogger>);
-        std::vector<char> ReadEngineFile(std::string);
-        ::nvinfer1::IRuntime* GetRuntime()
-        {
-            return m_Runtime.get();
-        }
-
-      private:
-        static Runtime* GetSingleton();
-
-        class Logger : public ::nvinfer1::ILogger
-        {
-          public:
-            void log(::nvinfer1::ILogger::Severity severity, const char* msg) final override;
-        };
-
-        // Order is important.  In C++ variables in the member initializer list are instantiated in
-        // the order they are declared, not in the order they appear in the initializer list.
-        // Inverting these causes m_Runtime to be initialized with a NULL m_Logger and was the
-        // source of much head banging.
-        std::unique_ptr<::nvinfer1::ILogger> m_Logger;
-        std::unique_ptr<::nvinfer1::IRuntime, NvInferDeleter> m_Runtime;
+        virtual ~Logger() override;
+        void log(::nvinfer1::ILogger::Severity severity, const char* msg) final override;
     };
 
-    /**
-     * @brief Convenience class wrapping nvinfer1::IRuntime and allowing DNN weights to be stored in
-     * unified memory, i.e. memory that can be paged between the host and the device.
-     *
-     * Extends the default Runtime to use CUDA Unified Memory as the memory type for the weight
-     * tensors in a TensorRT ICudaEngine.  This allows the weights to be paged in/out of device
-     * memory as needed. This is currently the only way to oversubscribe GPU memory so we can load
-     * more models than we have GPU memory available.
-     */
-    class ManagedRuntime : public Runtime
+    // Order is important.  In C++ variables in the member initializer list are instantiated in
+    // the order they are declared, not in the order they appear in the initializer list.
+    // Inverting these causes m_Runtime to be initialized with a NULL m_Logger and was the
+    // source of much head banging.
+    std::unique_ptr<::nvinfer1::ILogger> m_Logger;
+    std::unique_ptr<::nvinfer1::IRuntime, NvInferDeleter> m_NvRuntime;
+};
+
+class RuntimeWithAllocator : public Runtime 
+{
+  public:
+    using Runtime::Runtime;
+    virtual ~RuntimeWithAllocator() override;
+
+  protected:
+    RuntimeWithAllocator(std::unique_ptr<NvAllocator> allocator);
+    std::shared_ptr<Model> DeserializeEngine(const void*, size_t, ::nvinfer1::IPluginFactory*) final override;
+    NvAllocator& Allocator()
     {
-      public:
-        static std::shared_ptr<Model> DeserializeEngine(std::string plan_file);
-        virtual ~ManagedRuntime() override {}
-
-      protected:
-        struct Pointer
-        {
-            void* addr;
-            size_t size;
-        };
-
-        class ManagedAllocator final : public ::nvinfer1::IGpuAllocator
-        {
-          public:
-            // IGpuAllocator virtual overrides
-            void* allocate(uint64_t size, uint64_t alignment, uint32_t flags) final override;
-            void free(void* ptr) final override;
-
-            ManagedAllocator() : m_UseManagedMemory(false) {}
-            const std::vector<Pointer>& GetPointers()
-            {
-                return m_Pointers;
-            }
-
-          private:
-            std::vector<Pointer> m_Pointers;
-            std::recursive_mutex m_Mutex;
-            bool m_UseManagedMemory;
-
-            friend class ManagedRuntime;
-        };
-
-        ManagedAllocator* GetAllocator()
-        {
-            return m_Allocator.get();
-        }
-
-        template<class F, class... Args>
-        auto UseManagedMemory(F&& f, Args&&... args) -> typename std::result_of<F(Args...)>::type;
-
-      private:
-        ManagedRuntime();
-        static ManagedRuntime* GetSingleton();
-        std::unique_ptr<ManagedAllocator> m_Allocator;
-    };
-
-    template<class F, class... Args>
-    auto ManagedRuntime::UseManagedMemory(F&& f, Args&&... args) ->
-        typename std::result_of<F(Args...)>::type
-    {
-        std::lock_guard<std::recursive_mutex> lock(m_Allocator->m_Mutex);
-        m_Allocator->m_Pointers.clear();
-        m_Allocator->m_UseManagedMemory = true;
-        auto retval = f(std::forward<Args>(args)...);
-        m_Allocator->m_UseManagedMemory = false;
-        m_Allocator->m_Pointers.clear();
-        return retval;
+        return *m_Allocator;
     }
+
+  private:
+    std::unique_ptr<NvAllocator> m_Allocator;
+};
+
+template<typename AllocatorType>
+struct CustomRuntime : public RuntimeWithAllocator
+{
+    CustomRuntime() : RuntimeWithAllocator(std::make_unique<AllocatorType>()) {}
+    virtual ~CustomRuntime() override {}
+};
 
 } // namespace TensorRT
 } // namespace yais

--- a/tensorrt-playground/tensorrt/include/tensorrt/playground/runtime.h
+++ b/tensorrt-playground/tensorrt/include/tensorrt/playground/runtime.h
@@ -107,5 +107,8 @@ struct CustomRuntime : public RuntimeWithAllocator
     virtual ~CustomRuntime() override {}
 };
 
+using StandardRuntime = CustomRuntime<StandardAllocator>;
+using ManagedRuntime = CustomRuntime<ManagedAllocator>;
+
 } // namespace TensorRT
 } // namespace yais

--- a/tensorrt-playground/tensorrt/src/inference_manager.cc
+++ b/tensorrt-playground/tensorrt/src/inference_manager.cc
@@ -168,7 +168,7 @@ Runtime& InferenceManager::ActiveRuntime()
     return *m_ActiveRuntime;
 }
 
-void InferenceManager::RegisterRuntime(const std::string& name, std::unique_ptr<Runtime> runtime)
+void InferenceManager::RegisterRuntime(const std::string& name, std::shared_ptr<Runtime> runtime)
 {
     auto search = m_Runtimes.find(name);
     CHECK(search == m_Runtimes.end());


### PR DESCRIPTION
This is a break change to the TensorRT Runtime Wrappers.

In previous versions, one would access the TensorRT IRuntime interfaces through one of two static global singletons: `Runtime` or `ManagedRuntime` where the latter made use of Unified Memory for storing the weights of a model.

In the new version, one needs to create a shared_ptr to a `Runtime` object from either `StandardRuntime`, `ManagedRuntime`, or they can create their own by defining a new `IGpuAllocator` and instantiating a `Runtime` object via the `CustomRuntime` template class.